### PR TITLE
SUBAPI-40: Renamed AppExtensions to ApplicationBuilderExtensions

### DIFF
--- a/Submarine API/Api.Abstractions/Extensions/ApplicationBuilderExtensions.cs
+++ b/Submarine API/Api.Abstractions/Extensions/ApplicationBuilderExtensions.cs
@@ -4,7 +4,7 @@ using Microsoft.OpenApi.Models;
 
 namespace Diagnosea.Submarine.Api.Abstractions.Extensions
 {
-    public static class AppExtensions
+    public static class ApplicationBuilderExtensions
     {
         public static void AddSwagger(this IApplicationBuilder app, string pathBase)
         {


### PR DESCRIPTION
Fixes #40.